### PR TITLE
Call guarded method first.

### DIFF
--- a/lib/snagbug.dart
+++ b/lib/snagbug.dart
@@ -33,6 +33,11 @@ class Snagbug {
       main();
     }, _generateZoneGuard(onError));
 
+    // These come _after_ `main` to attempt to ensure compatibility issues do
+    // not interfere with the main application. With Flutter 1.22, we found an
+    // issue with running `MaterialApp` within `Provider` with this `Isolate`
+    // error handler coming first, on Android release builds, but dropping it
+    // here solved the problem. No other errors, warnings, or diagnosed causes.
     _wireUpFlutterErrorHandler(onError);
     _wireUpIsolateErrorHandler(onError);
   }

--- a/lib/snagbug.dart
+++ b/lib/snagbug.dart
@@ -29,12 +29,12 @@ class Snagbug {
 
   static void handleEveryError(Function main,
       {EveryErrorHandler onError = handleError}) {
-    _wireUpFlutterErrorHandler(onError);
-    _wireUpIsolateErrorHandler(onError);
-
     runZonedGuarded<Future<void>>(() async {
       main();
     }, _generateZoneGuard(onError));
+
+    _wireUpFlutterErrorHandler(onError);
+    _wireUpIsolateErrorHandler(onError);
   }
 
   static void _wireUpFlutterErrorHandler(EveryErrorHandler handler) {


### PR DESCRIPTION
We defer wiring up `FlutterError` and `Isolate` error handlers for...well, because it worked. Other arrangements fail on Android release builds.