### PR TITLE
Fix openURL handler eating URLs meant for other plugins.

### DIFF
--- a/ios/Classes/SwiftSnagbugPlugin.swift
+++ b/ios/Classes/SwiftSnagbugPlugin.swift
@@ -39,7 +39,7 @@ public class SwiftSnagbugPlugin: NSObject, FlutterPlugin {
 
     public func application(_: UIApplication, open _: URL, options _: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         startBugsnag()
-        return true
+        return false
     }
 
     private func startBugsnag() {


### PR DESCRIPTION
Notably, this change prevents this plugin from blocking others from receiving URLs via the same handler. Because it previously returned `true`, Flutter assumed the Snagbug plugin was responsible for that URL and doesn't notify later plugins.

This only _occasionally_ broke other plugins—such as Facebook login—because the flutter tooling doesn't use a stable package ordering when creating `GeneratedPluginRegistrant`, the file responsible for wiring all of this up inside of our iOS app. If the Snagbug plugin was later in the list, fewer packages were affected. Earlier, everything is broken.

That `GeneratedPluginRegistrant` file is not checked into CI and rebuilt every build. There was no good way to know ahead of time what other packages would be affected, and only _those_ packages would exhibit any symptoms that something was wrong.

Either way, this should fix it.